### PR TITLE
Add exists functionality / merge almost identical Write/Read test

### DIFF
--- a/extensions/adapter/storage/filesystem/File.php
+++ b/extensions/adapter/storage/filesystem/File.php
@@ -105,6 +105,24 @@ class File extends \lithium\core\Object {
 			return false;
 		};
 	}
+
+	/**
+	 * @param string $filename
+	 * @return boolean
+	 */
+	public function exists($filename) {
+		$path = $this->_config['path'];
+		return function($self, $params) use (&$path) {
+			$path = "{$path}/{$params['filename']}";
+
+			clearstatcache();
+			return file_exists($path);
+		};
+	}
+
+
 }
+
+
 
 ?>

--- a/extensions/storage/FileSystem.php
+++ b/extensions/storage/FileSystem.php
@@ -131,6 +131,28 @@ class FileSystem extends \lithium\core\Adaptable {
 		$params   = compact('filename');
 		return static::_filter(__FUNCTION__, $params, $method, $settings[$name]['filters']);
 	}
+
+	/**
+	 * Checks if the file from the specified filesystem configuration exists
+	 *
+	 * @param string $name Configuration to be used for deletion
+	 * @param mixed $filename a full path with filename and extension to be checked
+	 * @param mixed $options Options for the method and strategies.
+	 * @return boolean True on successful check, false otherwise
+	 * @filter This method may be filtered.
+	 */
+	public static function exists($name, $filename, array $options = array()) {
+		$settings = static::config();
+
+		if (!isset($settings[$name])) {
+			return false;
+		}
+
+		$method   = static::adapter($name)->exists($filename);
+		$params   = compact('filename');
+		return static::_filter(__FUNCTION__, $params, $method, $settings[$name]['filters']);
+	}
+
 }
 
 ?>

--- a/tests/integration/extensions/storage/FileSystemTest.php
+++ b/tests/integration/extensions/storage/FileSystemTest.php
@@ -57,46 +57,30 @@ class FileSystemTest extends \lithium\test\Integration {
 		$this->assertEqual($expected, $result);
 	}
 
-	public function testFileSystemWrite() {
+	public function testFileSystemActions() {
 		$config = array('default' => array(
 			'adapter' => 'File',
 			'filters' => array(),
 			'path'    => '/tmp'
 		));
-
 		FileSystem::config($config);
-
-		$result = FileSystem::config();
-		$this->assertEqual($config, $result);
 
 		$filename = 'test_file';
 		$data     = 'Some test content';
 
+		$this->assertFalse(FileSystem::exists('default', $filename));
+
 		$this->assertTrue(FileSystem::write('default', $filename, $data));
-		$this->assertEqual($data, FileSystem::read('default', $filename));
-		$this->assertTrue(FileSystem::delete('default', $filename));
-	}
 
-	public function testFileSystemRead() {
-		$config = array('default' => array(
-			'adapter' => 'File',
-			'filters' => array(),
-			'path'    => '/tmp'
-		));
-
-		FileSystem::config($config);
-		$result = FileSystem::config();
-		$this->assertEqual($config, $result);
-
-		$filename = 'test_file';
-		$data     = 'Some Test content';
-
-		$result = FileSystem::write('default', $filename, $data);
-		$this->assertTrue($result);
+		$this->assertTrue(FileSystem::exists('default', $filename));
 
 		$result = FileSystem::read('default', $filename);
 		$this->assertEqual($data, $result);
+
+		$this->assertTrue(FileSystem::delete('default', $filename));
 	}
+
+
 }
 
 ?>

--- a/tests/integration/storage/FileSystemTest.php
+++ b/tests/integration/storage/FileSystemTest.php
@@ -57,43 +57,27 @@ class FileSystemTest extends \lithium\test\Integration {
 		$this->assertEqual($expected, $result);
 	}
 
-	public function testFileSystemWrite() {
+	public function testFileSystemActions() {
 		$config = array('default' => array(
-			'adapter' => 'File',
+			'adapter' => '\li3_filesystem\tests\mocks\adapter\storage\filesystem\Mock',
 			'filters' => array(),
 			'path'    => '/tmp'
 		));
 		FileSystem::config($config);
-
-		$result = FileSystem::config();
-		$this->assertEqual($config, $result);
 
 		$filename = 'test_file';
 		$data     = 'Some test content';
 
+		$this->assertFalse(FileSystem::exists('default', $filename));
+
 		$this->assertTrue(FileSystem::write('default', $filename, $data));
-		$this->assertFalse(FileSystem::write('non_existing', $filename, $data));
-	}
 
-	public function testFileSystemRead() {
-		$config = array('default' => array(
-			'adapter' => 'File',
-			'filters' => array(),
-			'path'    => '/tmp'
-		));
-
-		FileSystem::config($config);
-		$result = FileSystem::config();
-		$this->assertEqual($config, $result);
-
-		$filename = 'test_file';
-		$data     = 'Some Test content';
-
-		$result = FileSystem::write('default', $filename, $data);
-		$this->assertTrue($result);
+		$this->assertTrue(FileSystem::exists('default', $filename));
 
 		$result = FileSystem::read('default', $filename);
 		$this->assertEqual($data, $result);
+
+		$this->assertTrue(FileSystem::delete('default', $filename));
 	}
 }
 


### PR DESCRIPTION
Now able to check if a file exists via the FileSystem

As the SystemWrite and SystemRead test are almost identical, they are merged
into one SystemActions (including a test for the exists)
